### PR TITLE
make GitHub repo cards obtained when building the whole site (instead of each time when a visitor accesses that page)

### DIFF
--- a/layouts/shortcodes/github-repo.html
+++ b/layouts/shortcodes/github-repo.html
@@ -1,3 +1,8 @@
 {{ $user := .Get "user" }}
 {{ $repo := .Get "repo" }}
-<p><a href="https://github.com/{{ $user }}/{{ $repo }}"><img src="https://gh-card.dev/repos/{{ $user }}/{{ $repo }}.svg" style="max-width: 100%;" /></a></p>
+{{ $url := printf "https://gh-card.dev/repos/%s/%s.svg" $user $repo }}
+{{ $svg := resources.GetRemote $url }}
+{{ $svgContent := $svg.Content }}
+<p class="upcards-github-repo-card">
+  <a href="https://github.com/{{ $user }}/{{ $repo }}">{{ $svgContent | safeHTML }}</a>
+</p>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -304,3 +304,9 @@ div.footnotes {
   object-fit: contain;
   border-radius: 10px 0 0 10px;
 }
+
+/* For disabling underlines on GitHub repository cards:
+.upcards-github-repo-card svg a {
+  text-decoration: none;
+}
+*/

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -305,8 +305,8 @@ div.footnotes {
   border-radius: 10px 0 0 10px;
 }
 
-/* For disabling underlines on GitHub repository cards:
 .upcards-github-repo-card svg a {
+/* For disabling underlines on GitHub repository cards:
   text-decoration: none;
-}
 */
+}


### PR DESCRIPTION
- Pros: putting less load on `https://gh-card.dev`
- Cons: the number of stargazers will be updated only when building the whole site